### PR TITLE
feat: provide access method with `api` for 7B:int8

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ docker run --gpus all --ipc=host --ulimit memlock=-1 -v `pwd`/models:/llama_data
 For **the minimum memory** requirements (7B almost 7.12GB) docker images, use the following command:
 
 ```bash
-docker run --gpus all --ipc=host --ulimit memlock=-1 -v `pwd`/models:/app/models -p 7860:7860 -it --rm soulteary/llama:int8
+docker run --gpus all --ipc=host --ulimit memlock=-1 -e PORT=7860 -v `pwd`/models:/app/models -p 7860:7860 -it --rm soulteary/llama:int8
 ```
 
 **For fine-tune**, [read this documentation](https://soulteary.com/2023/03/25/model-finetuning-on-llama-65b-large-model-using-docker-and-alpaca-lora.html).

--- a/docker/Dockerfile.int8
+++ b/docker/Dockerfile.int8
@@ -15,8 +15,11 @@ RUN git clone https://github.com/tloen/llama-int8.git && \
     python setup.py bdist_wheel && \
     pip install -r requirements.txt && \
     pip install -e . && \
-    pip install gradio
+    pip install gradio fastapi uvicorn
 
+COPY webui/api.py ./api.py
 COPY webui/int8.py ./webapp.py
 
-CMD ["python", "webapp.py"]
+ENV PORT=7860
+
+CMD uvicorn webapp:app --host 0.0.0.0 --port $PORT

--- a/webui/api.py
+++ b/webui/api.py
@@ -1,0 +1,74 @@
+from typing import Optional, Union, List
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+app_env = {
+    "app": app,
+    "generator": None # LLaMA
+}
+
+"""
+body: {
+    "prompts": ["text1", "text2],
+    "max_gen_len": 1024, # default
+    "temperature": 0.8, # default
+    "top_p": 0.95, # default
+    "repetition_penalty": { # default
+        "range": 1024,
+        "slope": 0,
+        "value": 1.15
+    }
+}
+"""
+
+class RepetitionPenalty(BaseModel):
+    range: Optional[int] = 1024
+    slope: Optional[float] = 0
+    value: Optional[float] = 1.15
+
+class GenerateParam(BaseModel):
+    prompts: Union[List[str], str]
+    max_gen_len: Optional[int] = 1024
+    temperature: Optional[float] = 0.8
+    top_p: Optional[float] = 0.95
+    repetition_penalty: Optional[RepetitionPenalty] = RepetitionPenalty()
+
+@app.post('/generate')
+async def generate(params: GenerateParam):
+    if len(params.prompts) == 0:
+        return {
+            "error": -1,
+            "msg": "There are prompts should be provided."
+        }
+
+    if type(params.prompts) is not list:
+        params.prompts = [params.prompts]
+
+    results = app_env["generator"].generate(
+        prompts = params.prompts,
+        max_gen_len = params.max_gen_len,
+        temperature = params.temperature,
+        top_p = params.top_p,
+        repetition_penalty_range = params.repetition_penalty.range,
+        repetition_penalty_slope = params.repetition_penalty.slope,
+        repetition_penalty = params.repetition_penalty.value
+    )
+
+    return {
+        "results": results
+    }
+
+
+def get_args():
+    # import argparse
+    # parser = argparse.ArgumentParser()
+    # parser.add_argument("--ckpt_dir", type=str, default="./models/7B")
+    # parser.add_argument("--tokenizer_path", type=str, default="./models/tokenizer.model")
+    # return parser.parse_args()
+
+    return {
+        "ckpt_dir": "./models/7B",
+        "tokenizer_path": "./models/tokenizer.model"
+    }


### PR DESCRIPTION
you can access it with follow:

    1. ui: input http://$host/, you can get a webpage.
    2. api: POST http://$host/generate, with `body`:
         class RepetitionPenalty(BaseModel):
             range: Optional[int] = 1024
             slope: Optional[float] = 0
             value: Optional[float] = 1.15

         class GenerateParam(BaseModel):
             prompts: Union[List[str], str]
             max_gen_len: Optional[int] = 1024
             temperature: Optional[float] = 0.8
             top_p: Optional[float] = 0.95
             repetition_penalty: Optional[RepetitionPenalty] = RepetitionPenalty()

        you can get a json:
            {
                  error: int,
                  msg: "error messages",
                  results: {results from llama}
            }